### PR TITLE
feat(terraform): create storage account and python script for uploading files to ADLS Gen2

### DIFF
--- a/data/upload_files_into_adls.py
+++ b/data/upload_files_into_adls.py
@@ -1,0 +1,76 @@
+import logging
+import argparse
+from pathlib import Path
+from azure.storage.filedatalake import DataLakeServiceClient
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(),  
+        logging.FileHandler('upload_files.log')  
+    ]
+)
+
+def get_service_client(storage_account_name, storage_account_key):
+    """
+    Create a DataLakeServiceClient instance to interact with Azure Data Lake.
+
+    Args:
+        storage_account_name (str): Azure Storage account name.
+        storage_account_key (str): Azure Storage account key.
+
+    Returns:
+        DataLakeServiceClient: Client for interacting with Azure Data Lake.
+    """
+    try:
+        service_client = DataLakeServiceClient(
+            account_url=f"https://{storage_account_name}.dfs.core.windows.net",
+            credential=storage_account_key
+        )
+        return service_client
+    
+    except Exception as e:
+        logging.error(f"Error creating DataLakeServiceClient: {e}", exc_info=True) 
+        raise Exception(f"Error creating DataLakeServiceClient: {e}")
+
+
+def upload_files(file_system_client, local_root_folder_path: Path):
+    """
+    Upload JSON files from a local directory to Azure Data Lake.
+
+    Args:
+        file_system_client (FileSystemClient): Client used to interact with a specific file system (container) in Azure Data Lake.
+        local_root_folder_path (Path): Local directory path to search for files.
+    """
+    try:
+        for local_file_path in local_root_folder_path.rglob('*.json'):
+            logging.info(f"Uploading file: {local_file_path}")
+            
+            file_client = file_system_client.get_file_client(local_file_path.relative_to(local_root_folder_path))
+
+            with open(local_file_path, "rb") as file_data:
+                file_contents = file_data.read()
+                file_client.upload_data(file_contents, overwrite=True) 
+
+    except Exception as e:
+        logging.error(f"Error during file upload process: {e}", exc_info=True) 
+        raise Exception(f"Error during file upload process: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Upload JSON files to Azure Data Lake.")
+    parser.add_argument('storage_account_name', help="Azure Storage account name.")
+    parser.add_argument('storage_account_key', help="Azure Storage account key.")
+    parser.add_argument('storage_container_name', help="Azure Storage container name.")
+    args = parser.parse_args()
+
+    service_client = get_service_client(args.storage_account_name, args.storage_account_key)
+    file_system_client = service_client.get_file_system_client(file_system=args.storage_container_name)
+    local_root_folder_path = Path("../data")
+
+    upload_files(file_system_client, local_root_folder_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -20,3 +20,22 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:f96be10c899c0e30870056ec9c2c5002ec2e4f07fe2a64e1b3135ec232ef6f1e",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.4"
+  hashes = [
+    "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}

--- a/infra/adlsgen2.tf
+++ b/infra/adlsgen2.tf
@@ -1,0 +1,24 @@
+resource "azurerm_storage_account" "adlsgen2" {
+    name                     = "adls${var.project_name}${terraform.workspace}"
+    resource_group_name      = var.resource_group_name
+    location                 = var.resource_group_location
+    account_replication_type = local.storage_account[terraform.workspace]["account_replication_type"]
+    account_tier             = local.storage_account[terraform.workspace]["account_tier"]
+    account_kind             = "StorageV2"
+    access_tier              = "Hot"
+    is_hns_enabled           = "true"
+
+    tags = {
+        Environment = local.tags[terraform.workspace]
+    }
+}
+
+resource "azurerm_storage_container" "container" {
+    name                     = "data"
+    storage_account_name     =  azurerm_storage_account.adlsgen2.name
+    container_access_type    = "private"
+
+    depends_on = [ 
+        azurerm_storage_account.adlsgen2
+    ]
+ }

--- a/infra/adlsgen2.tf
+++ b/infra/adlsgen2.tf
@@ -6,7 +6,7 @@ resource "azurerm_storage_account" "adlsgen2" {
     account_tier             = local.storage_account[terraform.workspace]["account_tier"]
     account_kind             = "StorageV2"
     access_tier              = "Hot"
-    is_hns_enabled           = "true"
+    is_hns_enabled           = true
 
     tags = {
         Environment = local.tags[terraform.workspace]
@@ -15,10 +15,24 @@ resource "azurerm_storage_account" "adlsgen2" {
 
 resource "azurerm_storage_container" "container" {
     name                     = "data"
-    storage_account_name     =  azurerm_storage_account.adlsgen2.name
+    storage_account_name     = azurerm_storage_account.adlsgen2.name
     container_access_type    = "private"
 
     depends_on = [ 
         azurerm_storage_account.adlsgen2
     ]
- }
+}
+
+resource "null_resource" "upload_data" {
+    provisioner "local-exec" {
+        command = <<EOT
+            ${path.module}/.venv/bin/python ${path.module}/../data/upload_files_into_adls.py \
+            ${azurerm_storage_account.adlsgen2.name} \
+            ${azurerm_storage_account.adlsgen2.primary_access_key} \
+            ${azurerm_storage_container.container.name}
+        EOT
+    }
+
+    depends_on = [azurerm_storage_account.adlsgen2, azurerm_storage_container.container]
+}
+

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,3 +1,5 @@
+### SP Terraform
+
 variable "subscription_id" {
   description = "Azure subscription ID"
   type        = string
@@ -22,6 +24,8 @@ variable "client_secret" {
   sensitive   = true
 }
 
+### Resource Group
+
 variable "resource_group_name" {
   type        = string
   description = "Name of the Azure resource group"
@@ -30,6 +34,13 @@ variable "resource_group_name" {
 variable "resource_group_location" {
   type        = string
   description = "Azure region where the resource group is created"
+}
+
+### Common Keyword
+
+variable "project_name" {
+  description = "Project name, used as common keyword to naming the resources"
+  type        = string
 }
 
 


### PR DESCRIPTION
This PR adds the following features to the project:

    Created an ADLS Gen2 Storage Account in Azure.

    Added an Azure Storage Container inside the ADLS Gen2 account.

    Implemented a Python script for uploading files to the storage container, triggered by a Terraform null_resource.

This enhances the project by integrating file storage and upload functionality with Azure.